### PR TITLE
feat(config): 初回起動時の通知スキップ機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ feeds:
 # フィードをチェックする間隔
 interval: 10m
 
+# 初回起動時（フィードの履歴が未保存のとき）に既存アイテムを通知せず、
+# 最新アイテムの時刻をベースラインとしてストアに記録するだけにする。
+# memory ストアならメモリ上、valkey ストアなら Valkey に保存されます。
+skip_initial_notify: false
+
 store:
   # 永続化にValkey (Redis) を使用する場合
   type: 'valkey'

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Init Components
 	whClient := webhook.NewClient()
-	fetcher := feed.NewFetcher(store, whClient, cfg.Webhooks.Webhooks)
+	fetcher := feed.NewFetcher(store, whClient, cfg.Webhooks.Webhooks, cfg.Feeds.SkipInitialNotify)
 
 	// Metrics Server
 	go func() {

--- a/config/feeds.yaml.example
+++ b/config/feeds.yaml.example
@@ -1,6 +1,10 @@
 feeds:
   - https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
 interval: 10s
+# If true, on the first run for a feed (no prior state), record the latest
+# item time as the baseline without sending notifications. Subsequent runs
+# notify only items newer than the baseline.
+skip_initial_notify: false
 store:
   # If you want to on-memory storage, set type to 'memory'
   # type: 'memory'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,9 +9,10 @@ import (
 )
 
 type FeedsConfig struct {
-	Feeds    []string      `yaml:"feeds"`
-	Interval time.Duration `yaml:"interval"`
-	Store    StoreConfig   `yaml:"store"`
+	Feeds             []string      `yaml:"feeds"`
+	Interval          time.Duration `yaml:"interval"`
+	Store             StoreConfig   `yaml:"store"`
+	SkipInitialNotify bool          `yaml:"skip_initial_notify"`
 }
 
 type StoreConfig struct {

--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -2,6 +2,7 @@ package feed
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sort"
 	"sync"
@@ -29,18 +30,20 @@ var (
 )
 
 type Fetcher struct {
-	store    state.Store
-	whClient *webhook.Client
-	webhooks []config.Webhook
-	parser   *gofeed.Parser
+	store             state.Store
+	whClient          *webhook.Client
+	webhooks          []config.Webhook
+	parser            *gofeed.Parser
+	skipInitialNotify bool
 }
 
-func NewFetcher(store state.Store, whClient *webhook.Client, webhooks []config.Webhook) *Fetcher {
+func NewFetcher(store state.Store, whClient *webhook.Client, webhooks []config.Webhook, skipInitialNotify bool) *Fetcher {
 	return &Fetcher{
-		store:    store,
-		whClient: whClient,
-		webhooks: webhooks,
-		parser:   gofeed.NewParser(),
+		store:             store,
+		whClient:          whClient,
+		webhooks:          webhooks,
+		parser:            gofeed.NewParser(),
+		skipInitialNotify: skipInitialNotify,
 	}
 }
 
@@ -56,7 +59,11 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 	}
 	metricFetchCount.WithLabelValues(feedURL, "success").Inc()
 
-	lastPub := f.store.GetLastPublishedAt(feedURL)
+	lastPub, stateErr := f.store.GetLastPublishedAt(feedURL)
+	firstRun := errors.Is(stateErr, state.ErrNoState)
+	if stateErr != nil && !firstRun {
+		logger.Error("Failed to read feed state, proceeding without baseline", "error", stateErr)
+	}
 
 	var newItems []*gofeed.Item
 
@@ -84,6 +91,13 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 	sort.Slice(newItems, func(i, j int) bool {
 		return newItems[i].PublishedParsed.Before(*newItems[j].PublishedParsed)
 	})
+
+	if f.skipInitialNotify && firstRun {
+		latest := *newItems[len(newItems)-1].PublishedParsed
+		f.store.SetLastPublishedAt(feedURL, latest)
+		logger.Info("Skipping initial notification, baseline recorded", "count", len(newItems), "latest", latest)
+		return
+	}
 
 	for _, item := range newItems {
 		payload := webhook.Payload{

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,25 +1,21 @@
 package state
 
 import (
+	"errors"
 	"sync"
 	"time"
 )
 
-// Store defines the interface for keeping track of processed items
+// ErrNoState is returned by Store.GetLastPublishedAt when no state has been
+// recorded yet for the given feed. Other errors indicate a transient or
+// data-integrity failure and must NOT be treated as "first run".
+var ErrNoState = errors.New("no stored state for feed")
+
+// Store defines the interface for keeping track of processed items.
+// GetLastPublishedAt returns ErrNoState if no entry exists; any other
+// non-nil error indicates a backend failure.
 type Store interface {
-	// IsNew checks if an item (identified by GUID or URL) has been seen before for a given feed.
-	// Returns true if new, false if already processed.
-	// Also marks it as seen if it is new.
-	// Ideally we want to just Ask "GetLastPublishedAt" or "HaveWeSeen(guid)".
-	// For RSS, typically we check if the item's PublishedDate > LastFetchedDate OR if we have not seen the GUID.
-	// Let's go with: UpdateLastProcessed(feedURL string, itemGUID string, publishedAt time.Time) error
-	// And Check(feedURL string, itemGUID string) bool
-	// But simpler: Store the latest PublishedAt for the feed. Any item newer than that is new.
-	// EXCEPT: if multiple items have same time.
-	// Let's stick to the plan: "LastRead(feedURL) time.Time".
-	// And maybe a dedupe cache for GUIDs if needed.
-	// For simplicity V1: Store LastPublishedAt for each feed.
-	GetLastPublishedAt(feedURL string) time.Time
+	GetLastPublishedAt(feedURL string) (time.Time, error)
 	SetLastPublishedAt(feedURL string, t time.Time)
 }
 
@@ -34,10 +30,14 @@ func NewMemoryStore() *MemoryStore {
 	}
 }
 
-func (s *MemoryStore) GetLastPublishedAt(feedURL string) time.Time {
+func (s *MemoryStore) GetLastPublishedAt(feedURL string) (time.Time, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.data[feedURL]
+	t, ok := s.data[feedURL]
+	if !ok {
+		return time.Time{}, ErrNoState
+	}
+	return t, nil
 }
 
 func (s *MemoryStore) SetLastPublishedAt(feedURL string, t time.Time) {

--- a/internal/state/valkey.go
+++ b/internal/state/valkey.go
@@ -29,25 +29,22 @@ func NewValkeyStore(addr, password string) (*ValkeyStore, error) {
 	return &ValkeyStore{client: rdb}, nil
 }
 
-func (s *ValkeyStore) GetLastPublishedAt(feedURL string) time.Time {
+func (s *ValkeyStore) GetLastPublishedAt(feedURL string) (time.Time, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	val, err := s.client.Get(ctx, "feed:"+feedURL).Result()
 	if err == redis.Nil {
-		return time.Time{}
+		return time.Time{}, ErrNoState
 	} else if err != nil {
-		// Log error? For interface simplicity we just return zero time, meaning "fetch all"
-		// Ideally we should handle error, but for V2 let's stick to interface.
-		// A potential improvement: Log via slog if we had access to logger here.
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("valkey get failed: %w", err)
 	}
 
 	t, err := time.Parse(time.RFC3339, val)
 	if err != nil {
-		return time.Time{}
+		return time.Time{}, fmt.Errorf("invalid stored timestamp %q: %w", val, err)
 	}
-	return t
+	return t, nil
 }
 
 func (s *ValkeyStore) SetLastPublishedAt(feedURL string, t time.Time) {


### PR DESCRIPTION
- feeds.yaml.exampleにskip_initial_notifyオプションを追加し、初回起動時に通知をスキップする設定を可能にした。
- config.goにSkipInitialNotifyフィールドを追加した。
- fetcher.goで初回起動時に通知をスキップするロジックを実装した。
- store.goおよびvalkey.goでGetLastPublishedAtメソッドを修正し、エラー処理を追加した。