### PR TITLE
feat(config): フィードの初回通知抑制とバースト通知制御を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,16 @@ feeds:
 # フィードをチェックする間隔
 interval: 10m
 
-# 初回起動時（フィードの履歴が未保存のとき）に既存アイテムを通知せず、
-# 最新アイテムの時刻をベースラインとしてストアに記録するだけにする。
-# memory ストアならメモリ上、valkey ストアなら Valkey に保存されます。
-skip_initial_notify: false
+# 比較可能な状態が保存されていないフィードでは通知せず、まず baseline を作る。
+# RSS が初回から全 item を返さない場合に、後から見えた既存 item を一括通知しないための設定です。
+skip_initial_notify: true
+
+# warming 中に「最新 item の時刻が変わらない」状態を何回連続で観測したら ready にするか。
+initial_warmup_stable_observations: 2
+
+# 1回の取得でこの件数を超える通知が出そうな場合は、通知せず baseline だけ進める。
+# 0 にするとこの guard を無効化します。
+max_notifications_per_feed_per_run: 10
 
 store:
   # 永続化にValkey (Redis) を使用する場合

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Init Components
 	whClient := webhook.NewClient()
-	fetcher := feed.NewFetcher(store, whClient, cfg.Webhooks.Webhooks, cfg.Feeds.SkipInitialNotify)
+	fetcher := feed.NewFetcher(store, whClient, cfg.Webhooks.Webhooks, cfg.Feeds)
 
 	// Metrics Server
 	go func() {

--- a/config/feeds.yaml.example
+++ b/config/feeds.yaml.example
@@ -1,10 +1,18 @@
 feeds:
   - https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
 interval: 10s
-# If true, on the first run for a feed (no prior state), record the latest
-# item time as the baseline without sending notifications. Subsequent runs
-# notify only items newer than the baseline.
-skip_initial_notify: false
+# If true, do not notify while a feed has no comparable state yet.
+# The fetcher records a baseline first, waits until the observed latest item
+# is stable, and only then starts notifying future items.
+skip_initial_notify: true
+
+# Number of consecutive observations with the same latest item time required
+# before a warming feed becomes ready.
+initial_warmup_stable_observations: 2
+
+# Suppress and advance the baseline if one feed would notify more than this
+# many items in a single run. Set 0 to disable this guard.
+max_notifications_per_feed_per_run: 10
 store:
   # If you want to on-memory storage, set type to 'memory'
   # type: 'memory'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,10 +9,12 @@ import (
 )
 
 type FeedsConfig struct {
-	Feeds             []string      `yaml:"feeds"`
-	Interval          time.Duration `yaml:"interval"`
-	Store             StoreConfig   `yaml:"store"`
-	SkipInitialNotify bool          `yaml:"skip_initial_notify"`
+	Feeds                           []string      `yaml:"feeds"`
+	Interval                        time.Duration `yaml:"interval"`
+	Store                           StoreConfig   `yaml:"store"`
+	SkipInitialNotify               bool          `yaml:"skip_initial_notify"`
+	InitialWarmupStableObservations int           `yaml:"initial_warmup_stable_observations"`
+	MaxNotificationsPerFeedPerRun   int           `yaml:"max_notifications_per_feed_per_run"`
 }
 
 type StoreConfig struct {
@@ -42,7 +44,10 @@ func Load(feedsPath, webhooksPath string) (*AppConfig, error) {
 	// Defaults
 	c := &AppConfig{
 		Feeds: &FeedsConfig{
-			Interval: 10 * time.Minute,
+			Interval:                        10 * time.Minute,
+			SkipInitialNotify:               true,
+			InitialWarmupStableObservations: 2,
+			MaxNotificationsPerFeedPerRun:   10,
 			Store: StoreConfig{
 				Type: "memory",
 			},
@@ -65,6 +70,12 @@ func Load(feedsPath, webhooksPath string) (*AppConfig, error) {
 	}
 	if len(c.Webhooks.Webhooks) == 0 {
 		return nil, fmt.Errorf("no webhooks configured")
+	}
+	if c.Feeds.InitialWarmupStableObservations < 1 {
+		return nil, fmt.Errorf("initial_warmup_stable_observations must be >= 1")
+	}
+	if c.Feeds.MaxNotificationsPerFeedPerRun < 0 {
+		return nil, fmt.Errorf("max_notifications_per_feed_per_run must be >= 0")
 	}
 
 	// Set default provider

--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -30,20 +30,24 @@ var (
 )
 
 type Fetcher struct {
-	store             state.Store
-	whClient          *webhook.Client
-	webhooks          []config.Webhook
-	parser            *gofeed.Parser
-	skipInitialNotify bool
+	store                           state.Store
+	whClient                        *webhook.Client
+	webhooks                        []config.Webhook
+	parser                          *gofeed.Parser
+	skipInitialNotify               bool
+	initialWarmupStableObservations int
+	maxNotificationsPerFeedPerRun   int
 }
 
-func NewFetcher(store state.Store, whClient *webhook.Client, webhooks []config.Webhook, skipInitialNotify bool) *Fetcher {
+func NewFetcher(store state.Store, whClient *webhook.Client, webhooks []config.Webhook, feedsConfig *config.FeedsConfig) *Fetcher {
 	return &Fetcher{
-		store:             store,
-		whClient:          whClient,
-		webhooks:          webhooks,
-		parser:            gofeed.NewParser(),
-		skipInitialNotify: skipInitialNotify,
+		store:                           store,
+		whClient:                        whClient,
+		webhooks:                        webhooks,
+		parser:                          gofeed.NewParser(),
+		skipInitialNotify:               feedsConfig.SkipInitialNotify,
+		initialWarmupStableObservations: feedsConfig.InitialWarmupStableObservations,
+		maxNotificationsPerFeedPerRun:   feedsConfig.MaxNotificationsPerFeedPerRun,
 	}
 }
 
@@ -59,45 +63,64 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 	}
 	metricFetchCount.WithLabelValues(feedURL, "success").Inc()
 
-	lastPub, stateErr := f.store.GetLastPublishedAt(feedURL)
-	firstRun := errors.Is(stateErr, state.ErrNoState)
-	if stateErr != nil && !firstRun {
-		logger.Error("Failed to read feed state, proceeding without baseline", "error", stateErr)
+	feedState, stateErr := f.store.GetFeedState(feedURL)
+	if stateErr != nil && !errors.Is(stateErr, state.ErrNoState) {
+		logger.Error("Failed to read feed state; skipping notification because baseline is not comparable", "error", stateErr)
+		return
 	}
 
-	var newItems []*gofeed.Item
+	items := itemsWithPublishedTime(feed.Items)
+	if len(items) == 0 {
+		logger.Debug("No comparable items")
+		return
+	}
 
-	for _, item := range feed.Items {
-		if item.PublishedParsed == nil {
-			if item.UpdatedParsed != nil {
-				item.PublishedParsed = item.UpdatedParsed
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].PublishedParsed.Before(*items[j].PublishedParsed)
+	})
+	latest := *items[len(items)-1].PublishedParsed
+
+	if errors.Is(stateErr, state.ErrNoState) {
+		if !f.skipInitialNotify {
+			feedState = state.NewReadyState(time.Time{})
+		} else {
+			feedState = state.NewWarmingState(latest, time.Now())
+			if err := f.store.SetFeedState(feedURL, feedState); err != nil {
+				logger.Error("Failed to record initial warming state", "error", err)
 			} else {
-				continue
+				logger.Info("Starting feed warmup; notification skipped", "latest", latest, "stable_observations", feedState.WarmupStableObservations)
 			}
-		}
-
-		if item.PublishedParsed.After(lastPub) {
-			newItems = append(newItems, item)
+			return
 		}
 	}
 
+	if feedState.Status == state.StatusWarming {
+		f.processWarmingFeed(feedURL, logger, feedState, latest)
+		return
+	}
+
+	if feedState.Status != state.StatusReady {
+		logger.Error("Unknown feed state status; skipping notification because baseline is not comparable", "status", feedState.Status)
+		return
+	}
+
+	newItems := itemsAfter(items, feedState.LastPublishedAt, feedState.NotifyAfter)
 	if len(newItems) == 0 {
 		logger.Debug("No new items")
 		return
 	}
 
-	logger.Info("Found new items", "count", len(newItems))
-
-	sort.Slice(newItems, func(i, j int) bool {
-		return newItems[i].PublishedParsed.Before(*newItems[j].PublishedParsed)
-	})
-
-	if f.skipInitialNotify && firstRun {
-		latest := *newItems[len(newItems)-1].PublishedParsed
-		f.store.SetLastPublishedAt(feedURL, latest)
-		logger.Info("Skipping initial notification, baseline recorded", "count", len(newItems), "latest", latest)
+	if f.maxNotificationsPerFeedPerRun > 0 && len(newItems) > f.maxNotificationsPerFeedPerRun {
+		nextState := state.NewReadyStateAfter(*newItems[len(newItems)-1].PublishedParsed, feedState.NotifyAfter)
+		if err := f.store.SetFeedState(feedURL, nextState); err != nil {
+			logger.Error("Failed to advance state after suppressing notification burst", "error", err, "count", len(newItems))
+			return
+		}
+		logger.Warn("Suppressed notification burst and advanced baseline", "count", len(newItems), "limit", f.maxNotificationsPerFeedPerRun, "latest", nextState.LastPublishedAt)
 		return
 	}
+
+	logger.Info("Found new items", "count", len(newItems))
 
 	for _, item := range newItems {
 		payload := webhook.Payload{
@@ -107,45 +130,69 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 			PublishedAt: *item.PublishedParsed,
 		}
 
-		// Broadcast to all configured webhooks
-		success := true
 		for _, wh := range f.webhooks {
 			if err := f.whClient.SendWithRateLimit(ctx, wh, payload); err != nil {
 				logger.Error("Failed to post webhook", "name", wh.Name, "item", item.Title, "error", err)
-				success = false
-				// If one webhook fails, do we stop? or try others?
-				// For now: Log and continue to others.
-				// But: should we mark item as processed?
-				// If we have critical webhook failure, we might want to NOT update state.
-				// Let's go with: if ALL fail, failure. If at least one succeeds, maybe success?
-				// User didn't specify. Conservative: if ANY fails, treat as partial failure?
-				// Simplest: Just try best effort.
 			}
 		}
 
-		// Determine if we should update state
-		if !success {
-			// If we failed to notify some webhooks, maybe we shouldn't advance state?
-			// But that would mean duplicate for successful ones next time.
-			// Ideally we track state per webhook? Too complex for now.
-			// Let's assume if at least one attempt was made, update state.
-			// OR: Simplistic approach as before -> break on error.
-			// Revert to: logic from before. If any error, break loop and don't update state.
-			// But now we have multiple webhooks.
-
-			// Let's decide: If sending to ANY webhook fails, log it but still mark as read?
-			// No, that risks data loss (user misses notification).
-			// If we don't mark as read, we repost to ALL next time (duplicate).
-			// Dilemma.
-			// Given "monitoring RSS" usually implies duplicates is better than missing.
-			// But for multiple webhooks, duplicates on A because B failed is annoying.
-			// Let's Log Error and Proceed. Updating state.
-		}
-
 		metricNewItems.WithLabelValues(feedURL).Inc()
-		f.store.SetLastPublishedAt(feedURL, *item.PublishedParsed)
+		nextState := state.NewReadyStateAfter(*item.PublishedParsed, feedState.NotifyAfter)
+		if err := f.store.SetFeedState(feedURL, nextState); err != nil {
+			logger.Error("Failed to update feed state after notification", "error", err, "title", item.Title)
+			return
+		}
 		logger.Info("Processed new item", "title", item.Title)
 	}
+}
+
+func (f *Fetcher) processWarmingFeed(feedURL string, logger *slog.Logger, feedState state.FeedState, latest time.Time) {
+	if latest.After(feedState.LastPublishedAt) {
+		feedState.LastPublishedAt = latest
+		feedState.WarmupStableObservations = 1
+	} else {
+		feedState.WarmupStableObservations++
+	}
+
+	if feedState.WarmupStableObservations >= f.initialWarmupStableObservations {
+		feedState = state.NewReadyStateAfter(feedState.LastPublishedAt, feedState.NotifyAfter)
+		if err := f.store.SetFeedState(feedURL, feedState); err != nil {
+			logger.Error("Failed to mark feed warmup complete", "error", err)
+			return
+		}
+		logger.Info("Feed warmup complete; baseline ready", "latest", feedState.LastPublishedAt)
+		return
+	}
+
+	if err := f.store.SetFeedState(feedURL, feedState); err != nil {
+		logger.Error("Failed to update feed warmup state", "error", err)
+		return
+	}
+	logger.Info("Feed warmup continuing; notification skipped", "latest", feedState.LastPublishedAt, "stable_observations", feedState.WarmupStableObservations, "required", f.initialWarmupStableObservations)
+}
+
+func itemsWithPublishedTime(items []*gofeed.Item) []*gofeed.Item {
+	out := make([]*gofeed.Item, 0, len(items))
+	for _, item := range items {
+		if item.PublishedParsed == nil {
+			if item.UpdatedParsed == nil {
+				continue
+			}
+			item.PublishedParsed = item.UpdatedParsed
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func itemsAfter(items []*gofeed.Item, baseline, notifyAfter time.Time) []*gofeed.Item {
+	out := make([]*gofeed.Item, 0, len(items))
+	for _, item := range items {
+		if item.PublishedParsed.After(baseline) && (notifyAfter.IsZero() || item.PublishedParsed.After(notifyAfter)) {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func (f *Fetcher) Run(ctx context.Context, feeds []string, interval time.Duration) {

--- a/internal/feed/fetcher_test.go
+++ b/internal/feed/fetcher_test.go
@@ -1,0 +1,139 @@
+package feed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"rss-fetcher/internal/config"
+	"rss-fetcher/internal/state"
+	"rss-fetcher/internal/webhook"
+)
+
+func TestWarmupSuppressesItemsPublishedBeforeWarmup(t *testing.T) {
+	old := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	lateVisible := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	newItem := time.Now().Add(1 * time.Hour).UTC().Truncate(time.Second)
+
+	var rss atomic.Value
+	rss.Store(rssFeed([]rssItem{{Title: "old", PublishedAt: old}}))
+
+	feedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rss.Load().(string))
+	}))
+	defer feedServer.Close()
+
+	var webhookCalls atomic.Int64
+	webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookCalls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer webhookServer.Close()
+
+	store := state.NewMemoryStore()
+	fetcher := NewFetcher(store, webhook.NewClient(), []config.Webhook{{
+		Name: "test",
+		URL:  webhookServer.URL,
+	}}, &config.FeedsConfig{
+		SkipInitialNotify:               true,
+		InitialWarmupStableObservations: 2,
+		MaxNotificationsPerFeedPerRun:   10,
+	})
+
+	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+
+	rss.Store(rssFeed([]rssItem{
+		{Title: "old", PublishedAt: old},
+		{Title: "late-visible", PublishedAt: lateVisible},
+	}))
+	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+
+	if got := webhookCalls.Load(); got != 0 {
+		t.Fatalf("webhook calls after late-visible historical item = %d, want 0", got)
+	}
+
+	rss.Store(rssFeed([]rssItem{
+		{Title: "old", PublishedAt: old},
+		{Title: "late-visible", PublishedAt: lateVisible},
+		{Title: "new", PublishedAt: newItem},
+	}))
+	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+
+	if got := webhookCalls.Load(); got != 1 {
+		t.Fatalf("webhook calls after new item = %d, want 1", got)
+	}
+}
+
+func TestBurstSuppressionAdvancesBaselineWithoutNotifications(t *testing.T) {
+	baseline := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	items := []rssItem{
+		{Title: "one", PublishedAt: baseline.Add(1 * time.Minute)},
+		{Title: "two", PublishedAt: baseline.Add(2 * time.Minute)},
+		{Title: "three", PublishedAt: baseline.Add(3 * time.Minute)},
+	}
+
+	feedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rssFeed(items))
+	}))
+	defer feedServer.Close()
+
+	var webhookCalls atomic.Int64
+	webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		webhookCalls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer webhookServer.Close()
+
+	store := state.NewMemoryStore()
+	if err := store.SetFeedState(feedServer.URL, state.NewReadyState(baseline)); err != nil {
+		t.Fatal(err)
+	}
+
+	fetcher := NewFetcher(store, webhook.NewClient(), []config.Webhook{{
+		Name: "test",
+		URL:  webhookServer.URL,
+	}}, &config.FeedsConfig{
+		InitialWarmupStableObservations: 2,
+		MaxNotificationsPerFeedPerRun:   2,
+	})
+
+	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+
+	if got := webhookCalls.Load(); got != 0 {
+		t.Fatalf("webhook calls after suppressed burst = %d, want 0", got)
+	}
+
+	st, err := store.GetFeedState(feedServer.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.LastPublishedAt.Equal(items[len(items)-1].PublishedAt) {
+		t.Fatalf("baseline = %s, want %s", st.LastPublishedAt, items[len(items)-1].PublishedAt)
+	}
+}
+
+type rssItem struct {
+	Title       string
+	PublishedAt time.Time
+}
+
+func rssFeed(items []rssItem) string {
+	out := `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>test feed</title>`
+	for i, item := range items {
+		out += fmt.Sprintf(
+			`<item><title>%s</title><link>https://example.com/%d</link><guid>https://example.com/%d</guid><pubDate>%s</pubDate></item>`,
+			item.Title,
+			i,
+			i,
+			item.PublishedAt.Format(time.RFC1123Z),
+		)
+	}
+	return out + `</channel></rss>`
+}

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,49 +1,125 @@
 package state
 
 import (
+	"encoding/json"
 	"errors"
 	"sync"
 	"time"
 )
 
-// ErrNoState is returned by Store.GetLastPublishedAt when no state has been
+const (
+	StatusWarming = "warming"
+	StatusReady   = "ready"
+)
+
+// ErrNoState is returned by Store.GetFeedState when no state has been
 // recorded yet for the given feed. Other errors indicate a transient or
 // data-integrity failure and must NOT be treated as "first run".
 var ErrNoState = errors.New("no stored state for feed")
 
+type FeedState struct {
+	Version                  int       `json:"version"`
+	Status                   string    `json:"status"`
+	LastPublishedAt          time.Time `json:"last_published_at"`
+	NotifyAfter              time.Time `json:"notify_after"`
+	WarmupStableObservations int       `json:"warmup_stable_observations"`
+}
+
 // Store defines the interface for keeping track of processed items.
-// GetLastPublishedAt returns ErrNoState if no entry exists; any other
+// GetFeedState returns ErrNoState if no entry exists; any other
 // non-nil error indicates a backend failure.
 type Store interface {
-	GetLastPublishedAt(feedURL string) (time.Time, error)
-	SetLastPublishedAt(feedURL string, t time.Time)
+	GetFeedState(feedURL string) (FeedState, error)
+	SetFeedState(feedURL string, state FeedState) error
+}
+
+func NewWarmingState(lastPublishedAt, notifyAfter time.Time) FeedState {
+	return FeedState{
+		Version:                  1,
+		Status:                   StatusWarming,
+		LastPublishedAt:          lastPublishedAt,
+		NotifyAfter:              notifyAfter,
+		WarmupStableObservations: 1,
+	}
+}
+
+func NewReadyState(lastPublishedAt time.Time) FeedState {
+	return NewReadyStateAfter(lastPublishedAt, time.Time{})
+}
+
+func NewReadyStateAfter(lastPublishedAt, notifyAfter time.Time) FeedState {
+	return FeedState{
+		Version:                  1,
+		Status:                   StatusReady,
+		LastPublishedAt:          lastPublishedAt,
+		NotifyAfter:              notifyAfter,
+		WarmupStableObservations: 0,
+	}
+}
+
+func DecodeFeedState(raw string) (FeedState, error) {
+	var st FeedState
+	if err := json.Unmarshal([]byte(raw), &st); err == nil {
+		if st.Version == 0 {
+			st.Version = 1
+		}
+		if st.Status == "" {
+			return FeedState{}, errors.New("missing feed state status")
+		}
+		if st.Status != StatusWarming && st.Status != StatusReady {
+			return FeedState{}, errors.New("unknown feed state status")
+		}
+		if st.LastPublishedAt.IsZero() {
+			return FeedState{}, errors.New("missing feed state baseline")
+		}
+		return st, nil
+	}
+
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return FeedState{}, err
+	}
+	return NewReadyState(t), nil
+}
+
+func EncodeFeedState(st FeedState) (string, error) {
+	if st.Version == 0 {
+		st.Version = 1
+	}
+	data, err := json.Marshal(st)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 type MemoryStore struct {
 	mu   sync.RWMutex
-	data map[string]time.Time
+	data map[string]FeedState
 }
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		data: make(map[string]time.Time),
+		data: make(map[string]FeedState),
 	}
 }
 
-func (s *MemoryStore) GetLastPublishedAt(feedURL string) (time.Time, error) {
+func (s *MemoryStore) GetFeedState(feedURL string) (FeedState, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	t, ok := s.data[feedURL]
+	st, ok := s.data[feedURL]
 	if !ok {
-		return time.Time{}, ErrNoState
+		return FeedState{}, ErrNoState
 	}
-	return t, nil
+	return st, nil
 }
 
-func (s *MemoryStore) SetLastPublishedAt(feedURL string, t time.Time) {
+func (s *MemoryStore) SetFeedState(feedURL string, st FeedState) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Monotonic increase only? Not necessarily, but for this usecase usually yes.
-	// But we just overwrite with the latest we successfully processed.
-	s.data[feedURL] = t
+	if st.Version == 0 {
+		st.Version = 1
+	}
+	s.data[feedURL] = st
+	return nil
 }

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -1,0 +1,28 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDecodeFeedStateMigratesLegacyTimestamp(t *testing.T) {
+	ts := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+
+	st, err := DecodeFeedState(ts.Format(time.RFC3339))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if st.Status != StatusReady {
+		t.Fatalf("status = %q, want %q", st.Status, StatusReady)
+	}
+	if !st.LastPublishedAt.Equal(ts) {
+		t.Fatalf("last published at = %s, want %s", st.LastPublishedAt, ts)
+	}
+}
+
+func TestDecodeFeedStateRejectsMalformedJSONState(t *testing.T) {
+	if _, err := DecodeFeedState(`{"version":1}`); err == nil {
+		t.Fatal("DecodeFeedState returned nil error for malformed JSON state")
+	}
+}

--- a/internal/state/valkey.go
+++ b/internal/state/valkey.go
@@ -29,28 +29,34 @@ func NewValkeyStore(addr, password string) (*ValkeyStore, error) {
 	return &ValkeyStore{client: rdb}, nil
 }
 
-func (s *ValkeyStore) GetLastPublishedAt(feedURL string) (time.Time, error) {
+func (s *ValkeyStore) GetFeedState(feedURL string) (FeedState, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	val, err := s.client.Get(ctx, "feed:"+feedURL).Result()
 	if err == redis.Nil {
-		return time.Time{}, ErrNoState
+		return FeedState{}, ErrNoState
 	} else if err != nil {
-		return time.Time{}, fmt.Errorf("valkey get failed: %w", err)
+		return FeedState{}, fmt.Errorf("valkey get failed: %w", err)
 	}
 
-	t, err := time.Parse(time.RFC3339, val)
+	st, err := DecodeFeedState(val)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid stored timestamp %q: %w", val, err)
+		return FeedState{}, fmt.Errorf("invalid stored feed state %q: %w", val, err)
 	}
-	return t, nil
+	return st, nil
 }
 
-func (s *ValkeyStore) SetLastPublishedAt(feedURL string, t time.Time) {
+func (s *ValkeyStore) SetFeedState(feedURL string, st FeedState) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	// Store as RFC3339 string
-	s.client.Set(ctx, "feed:"+feedURL, t.Format(time.RFC3339), 0)
+	encoded, err := EncodeFeedState(st)
+	if err != nil {
+		return fmt.Errorf("encode feed state failed: %w", err)
+	}
+	if err := s.client.Set(ctx, "feed:"+feedURL, encoded, 0).Err(); err != nil {
+		return fmt.Errorf("valkey set failed: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
- README.md: 初回通知抑制とバースト通知制御の設定を追加
- main.go: フェッチャーの初期化時に設定を渡すように変更
- feeds.yaml.example: 新しい設定項目を追加
- config.go: 新しい設定項目を構造体に追加
- fetcher.go: フィード処理時の通知抑制ロジックを実装
- store.go: フィード状態を管理するための構造体を追加
- store_test.go: フィード状態のデコードテストを追加
- valkey.go: Valkeyストアでフィード状態を管理するように変更
- fetcher_test.go: 新しい機能に対するテストを追加