### PR TITLE
feat(config): フィード設定に名前とURLのサポートを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ docker compose up --build -d
 
 ```yaml
 feeds:
-  - https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml
-  - https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
+  - name: nytimes-technology
+    url: https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml
+  - name: youtube-channel
+    url: https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
+  # URLだけの既存形式も利用できます。
+  # - https://example.com/rss.xml
 
 # フィードをチェックする間隔
 interval: 10m

--- a/config/feeds.yaml.example
+++ b/config/feeds.yaml.example
@@ -1,5 +1,8 @@
 feeds:
-  - https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
+  - name: example-channel
+    url: https://www.youtube.com/feeds/videos.xml?channel_id=UCRcLAVTbmx2-iNcXSsupdNA
+  # URL-only entries are also supported:
+  # - https://example.com/rss.xml
 interval: 10s
 # If true, do not notify while a feed has no comparable state yet.
 # The fetcher records a baseline first, waits until the observed latest item

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,12 +9,46 @@ import (
 )
 
 type FeedsConfig struct {
-	Feeds                           []string      `yaml:"feeds"`
+	Feeds                           []Feed        `yaml:"feeds"`
 	Interval                        time.Duration `yaml:"interval"`
 	Store                           StoreConfig   `yaml:"store"`
 	SkipInitialNotify               bool          `yaml:"skip_initial_notify"`
 	InitialWarmupStableObservations int           `yaml:"initial_warmup_stable_observations"`
 	MaxNotificationsPerFeedPerRun   int           `yaml:"max_notifications_per_feed_per_run"`
+}
+
+type Feed struct {
+	Name string `yaml:"name"`
+	URL  string `yaml:"url"`
+}
+
+func (f Feed) Label() string {
+	if f.Name != "" {
+		return f.Name
+	}
+	return f.URL
+}
+
+func (f *Feed) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		var url string
+		if err := value.Decode(&url); err != nil {
+			return err
+		}
+		f.URL = url
+		return nil
+	case yaml.MappingNode:
+		type feed Feed
+		var decoded feed
+		if err := value.Decode(&decoded); err != nil {
+			return err
+		}
+		*f = Feed(decoded)
+		return nil
+	default:
+		return fmt.Errorf("feed must be a URL string or mapping with url/name")
+	}
 }
 
 type StoreConfig struct {
@@ -67,6 +101,11 @@ func Load(feedsPath, webhooksPath string) (*AppConfig, error) {
 
 	if len(c.Feeds.Feeds) == 0 {
 		return nil, fmt.Errorf("no feeds configured")
+	}
+	for i, feed := range c.Feeds.Feeds {
+		if feed.URL == "" {
+			return nil, fmt.Errorf("feeds[%d].url is required", i)
+		}
 	}
 	if len(c.Webhooks.Webhooks) == 0 {
 		return nil, fmt.Errorf("no webhooks configured")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSupportsStringAndNamedFeeds(t *testing.T) {
+	dir := t.TempDir()
+	feedsPath := filepath.Join(dir, "feeds.yaml")
+	webhooksPath := filepath.Join(dir, "webhooks.yaml")
+
+	if err := os.WriteFile(feedsPath, []byte(`
+feeds:
+  - https://example.com/rss.xml
+  - name: Example Blog
+    url: https://example.com/blog.xml
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(webhooksPath, []byte(`
+webhooks:
+  - name: test
+    url: https://example.com/webhook
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(feedsPath, webhooksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.Feeds.Feeds[0].URL; got != "https://example.com/rss.xml" {
+		t.Fatalf("first feed URL = %q", got)
+	}
+	if got := cfg.Feeds.Feeds[0].Label(); got != "https://example.com/rss.xml" {
+		t.Fatalf("first feed label = %q", got)
+	}
+	if got := cfg.Feeds.Feeds[1].Name; got != "Example Blog" {
+		t.Fatalf("second feed name = %q", got)
+	}
+	if got := cfg.Feeds.Feeds[1].Label(); got != "Example Blog" {
+		t.Fatalf("second feed label = %q", got)
+	}
+}
+
+func TestLoadRejectsNamedFeedWithoutURL(t *testing.T) {
+	dir := t.TempDir()
+	feedsPath := filepath.Join(dir, "feeds.yaml")
+	webhooksPath := filepath.Join(dir, "webhooks.yaml")
+
+	if err := os.WriteFile(feedsPath, []byte(`
+feeds:
+  - name: Missing URL
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(webhooksPath, []byte(`
+webhooks:
+  - name: test
+    url: https://example.com/webhook
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(feedsPath, webhooksPath); err == nil {
+		t.Fatal("Load returned nil error for feed without URL")
+	}
+}

--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -51,17 +51,19 @@ func NewFetcher(store state.Store, whClient *webhook.Client, webhooks []config.W
 	}
 }
 
-func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
-	logger := slog.With("feed", feedURL)
+func (f *Fetcher) ProcessFeed(ctx context.Context, feedConfig config.Feed) {
+	feedURL := feedConfig.URL
+	feedLabel := feedConfig.Label()
+	logger := slog.With("feed", feedLabel, "feed_url", feedURL)
 	logger.Info("Checking feed")
 
 	feed, err := f.parser.ParseURLWithContext(feedURL, ctx)
 	if err != nil {
 		logger.Error("Failed to parse feed", "error", err)
-		metricFetchCount.WithLabelValues(feedURL, "error").Inc()
+		metricFetchCount.WithLabelValues(feedLabel, "error").Inc()
 		return
 	}
-	metricFetchCount.WithLabelValues(feedURL, "success").Inc()
+	metricFetchCount.WithLabelValues(feedLabel, "success").Inc()
 
 	feedState, stateErr := f.store.GetFeedState(feedURL)
 	if stateErr != nil && !errors.Is(stateErr, state.ErrNoState) {
@@ -124,7 +126,7 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 
 	for _, item := range newItems {
 		payload := webhook.Payload{
-			FeedTitle:   feed.Title,
+			FeedTitle:   feedTitle(feedConfig, feed.Title),
 			ItemTitle:   item.Title,
 			ItemURL:     item.Link,
 			PublishedAt: *item.PublishedParsed,
@@ -136,7 +138,7 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 			}
 		}
 
-		metricNewItems.WithLabelValues(feedURL).Inc()
+		metricNewItems.WithLabelValues(feedLabel).Inc()
 		nextState := state.NewReadyStateAfter(*item.PublishedParsed, feedState.NotifyAfter)
 		if err := f.store.SetFeedState(feedURL, nextState); err != nil {
 			logger.Error("Failed to update feed state after notification", "error", err, "title", item.Title)
@@ -144,6 +146,13 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedURL string) {
 		}
 		logger.Info("Processed new item", "title", item.Title)
 	}
+}
+
+func feedTitle(feedConfig config.Feed, parsedTitle string) string {
+	if feedConfig.Name != "" {
+		return feedConfig.Name
+	}
+	return parsedTitle
 }
 
 func (f *Fetcher) processWarmingFeed(feedURL string, logger *slog.Logger, feedState state.FeedState, latest time.Time) {
@@ -195,7 +204,7 @@ func itemsAfter(items []*gofeed.Item, baseline, notifyAfter time.Time) []*gofeed
 	return out
 }
 
-func (f *Fetcher) Run(ctx context.Context, feeds []string, interval time.Duration) {
+func (f *Fetcher) Run(ctx context.Context, feeds []config.Feed, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -211,16 +220,16 @@ func (f *Fetcher) Run(ctx context.Context, feeds []string, interval time.Duratio
 	}
 }
 
-func (f *Fetcher) runOnce(ctx context.Context, feeds []string) {
+func (f *Fetcher) runOnce(ctx context.Context, feeds []config.Feed) {
 	var wg sync.WaitGroup
-	for _, feedURL := range feeds {
+	for _, feedConfig := range feeds {
 		wg.Add(1)
-		go func(url string) {
+		go func(feedConfig config.Feed) {
 			defer wg.Done()
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Minute) // Increased timeout for rate limits
 			defer cancel()
-			f.ProcessFeed(ctx, url)
-		}(feedURL)
+			f.ProcessFeed(ctx, feedConfig)
+		}(feedConfig)
 	}
 	wg.Wait()
 }

--- a/internal/feed/fetcher_test.go
+++ b/internal/feed/fetcher_test.go
@@ -2,6 +2,7 @@ package feed
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -45,14 +46,16 @@ func TestWarmupSuppressesItemsPublishedBeforeWarmup(t *testing.T) {
 		MaxNotificationsPerFeedPerRun:   10,
 	})
 
-	fetcher.ProcessFeed(context.Background(), feedServer.URL)
-	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+	feedConfig := config.Feed{URL: feedServer.URL}
+
+	fetcher.ProcessFeed(context.Background(), feedConfig)
+	fetcher.ProcessFeed(context.Background(), feedConfig)
 
 	rss.Store(rssFeed([]rssItem{
 		{Title: "old", PublishedAt: old},
 		{Title: "late-visible", PublishedAt: lateVisible},
 	}))
-	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+	fetcher.ProcessFeed(context.Background(), feedConfig)
 
 	if got := webhookCalls.Load(); got != 0 {
 		t.Fatalf("webhook calls after late-visible historical item = %d, want 0", got)
@@ -63,7 +66,7 @@ func TestWarmupSuppressesItemsPublishedBeforeWarmup(t *testing.T) {
 		{Title: "late-visible", PublishedAt: lateVisible},
 		{Title: "new", PublishedAt: newItem},
 	}))
-	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+	fetcher.ProcessFeed(context.Background(), feedConfig)
 
 	if got := webhookCalls.Load(); got != 1 {
 		t.Fatalf("webhook calls after new item = %d, want 1", got)
@@ -104,7 +107,7 @@ func TestBurstSuppressionAdvancesBaselineWithoutNotifications(t *testing.T) {
 		MaxNotificationsPerFeedPerRun:   2,
 	})
 
-	fetcher.ProcessFeed(context.Background(), feedServer.URL)
+	fetcher.ProcessFeed(context.Background(), config.Feed{URL: feedServer.URL})
 
 	if got := webhookCalls.Load(); got != 0 {
 		t.Fatalf("webhook calls after suppressed burst = %d, want 0", got)
@@ -116,6 +119,54 @@ func TestBurstSuppressionAdvancesBaselineWithoutNotifications(t *testing.T) {
 	}
 	if !st.LastPublishedAt.Equal(items[len(items)-1].PublishedAt) {
 		t.Fatalf("baseline = %s, want %s", st.LastPublishedAt, items[len(items)-1].PublishedAt)
+	}
+}
+
+func TestConfiguredFeedNameIsUsedInWebhookPayload(t *testing.T) {
+	baseline := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	newItem := baseline.Add(1 * time.Minute)
+
+	feedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		fmt.Fprint(w, rssFeed([]rssItem{{Title: "new", PublishedAt: newItem}}))
+	}))
+	defer feedServer.Close()
+
+	payloads := make(chan webhook.DiscordPayload, 1)
+	webhookServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload webhook.DiscordPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("failed to decode webhook payload: %v", err)
+		}
+		payloads <- payload
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer webhookServer.Close()
+
+	store := state.NewMemoryStore()
+	if err := store.SetFeedState(feedServer.URL, state.NewReadyState(baseline)); err != nil {
+		t.Fatal(err)
+	}
+
+	fetcher := NewFetcher(store, webhook.NewClient(), []config.Webhook{{
+		Name:     "test",
+		URL:      webhookServer.URL,
+		Provider: "discord",
+	}}, &config.FeedsConfig{
+		InitialWarmupStableObservations: 2,
+		MaxNotificationsPerFeedPerRun:   10,
+	})
+
+	fetcher.ProcessFeed(context.Background(), config.Feed{Name: "Release Notes", URL: feedServer.URL})
+
+	select {
+	case got := <-payloads:
+		want := "**Release Notes**\nnew\nhttps://example.com/0"
+		if got.Content != want {
+			t.Fatalf("webhook content = %q, want %q", got.Content, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("webhook was not called")
 	}
 }
 


### PR DESCRIPTION
- README.md: フィード設定の例を名前とURL形式に更新
- config/feeds.yaml.example: フィード設定の例を名前とURL形式に更新
- internal/config/config.go: フィード設定を構造体に変更し、名前とURLを持つように修正
- internal/config/config_test.go: 名前付きフィードのテストを追加
- internal/feed/fetcher.go: フィード処理で名前を使用するように修正
- internal/feed/fetcher_test.go: 名前付きフィードのWebhookペイロードテストを追加