### PR TITLE
fix(feed): ウェブフックペイロードでフィードタイトルを使用するように修正

### DIFF
--- a/internal/feed/fetcher.go
+++ b/internal/feed/fetcher.go
@@ -126,7 +126,7 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedConfig config.Feed) {
 
 	for _, item := range newItems {
 		payload := webhook.Payload{
-			FeedTitle:   feedTitle(feedConfig, feed.Title),
+			FeedTitle:   feed.Title,
 			ItemTitle:   item.Title,
 			ItemURL:     item.Link,
 			PublishedAt: *item.PublishedParsed,
@@ -146,13 +146,6 @@ func (f *Fetcher) ProcessFeed(ctx context.Context, feedConfig config.Feed) {
 		}
 		logger.Info("Processed new item", "title", item.Title)
 	}
-}
-
-func feedTitle(feedConfig config.Feed, parsedTitle string) string {
-	if feedConfig.Name != "" {
-		return feedConfig.Name
-	}
-	return parsedTitle
 }
 
 func (f *Fetcher) processWarmingFeed(feedURL string, logger *slog.Logger, feedState state.FeedState, latest time.Time) {

--- a/internal/feed/fetcher_test.go
+++ b/internal/feed/fetcher_test.go
@@ -122,7 +122,7 @@ func TestBurstSuppressionAdvancesBaselineWithoutNotifications(t *testing.T) {
 	}
 }
 
-func TestConfiguredFeedNameIsUsedInWebhookPayload(t *testing.T) {
+func TestWebhookPayloadUsesRSSFeedTitleWhenConfiguredNameExists(t *testing.T) {
 	baseline := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
 	newItem := baseline.Add(1 * time.Minute)
 
@@ -161,7 +161,7 @@ func TestConfiguredFeedNameIsUsedInWebhookPayload(t *testing.T) {
 
 	select {
 	case got := <-payloads:
-		want := "**Release Notes**\nnew\nhttps://example.com/0"
+		want := "**test feed**\nnew\nhttps://example.com/0"
 		if got.Content != want {
 			t.Fatalf("webhook content = %q, want %q", got.Content, want)
 		}


### PR DESCRIPTION
- fetcher.go: feedTitle関数を削除し、ウェブフックペイロードで直接フィードタイトルを使用するように変更
- fetcher_test.go: テスト関数名を変更し、期待されるペイロード内容をフィードタイトルに合わせて修正