### PR TITLE
fix: require webhooks[].url in config validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,11 @@ func Load(feedsPath, webhooksPath string) (*AppConfig, error) {
 	if len(c.Webhooks.Webhooks) == 0 {
 		return nil, fmt.Errorf("no webhooks configured")
 	}
+	for i, wh := range c.Webhooks.Webhooks {
+		if wh.URL == "" {
+			return nil, fmt.Errorf("webhooks[%d].url is required", i)
+		}
+	}
 	if c.Feeds.InitialWarmupStableObservations < 1 {
 		return nil, fmt.Errorf("initial_warmup_stable_observations must be >= 1")
 	}


### PR DESCRIPTION
feeds[].url は起動時バリデーションで必須チェックされているが、webhooks[].url には同等のチェックが無かった。wh.URL は全プロバイダで無条件に使われる(misskey は URL に path を付与して使う)ので、欠けていると起動時ではなく post 時にわかりにくい HTTP エラーとして顕在化する。feeds と同じパターンでチェックを追加。

ついでに、この PR のマージ後の release-please → chart-release.yaml の経路(appVersion 自動更新 → chart re-publish)の実地検証も兼ねます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)