### PR TITLE
chore(ci): bump the pinned shared-workflows sha

### DIFF
--- a/.github/workflows/chart-guard.yaml
+++ b/.github/workflows/chart-guard.yaml
@@ -14,4 +14,4 @@ jobs:
     name: Guard chart version
     permissions:
       contents: read
-    uses: Soli0222/shared-workflows/.github/workflows/chart-guard.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
+    uses: Soli0222/shared-workflows/.github/workflows/chart-guard.yaml@119de6bc19fdd3e2d77f0decb8bd5bd976a7a645

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -80,6 +80,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
+    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@119de6bc19fdd3e2d77f0decb8bd5bd976a7a645
     with:
       api-versions: monitoring.coreos.com/v1

--- a/.github/workflows/release-retry.yaml
+++ b/.github/workflows/release-retry.yaml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
+    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@119de6bc19fdd3e2d77f0decb8bd5bd976a7a645
     with:
       ref: ${{ needs.resolve.outputs.sha }}
       version: ${{ inputs.version }}
@@ -67,6 +67,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
+    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@119de6bc19fdd3e2d77f0decb8bd5bd976a7a645
     with:
       api-versions: monitoring.coreos.com/v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
+    uses: Soli0222/shared-workflows/.github/workflows/publish-image.yaml@119de6bc19fdd3e2d77f0decb8bd5bd976a7a645
     with:
       ref: ${{ needs.release-please.outputs.sha }}
       version: ${{ needs.release-please.outputs.version }}
@@ -62,6 +62,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@75c1e8b572ce9ea8ad611d68232cb922a19acdeb
+    uses: Soli0222/shared-workflows/.github/workflows/publish-chart.yaml@119de6bc19fdd3e2d77f0decb8bd5bd976a7a645
     with:
       api-versions: monitoring.coreos.com/v1


### PR DESCRIPTION
chart-guard が base 側に存在しない chart (= 新規追加された chart) を扱えず、`git archive` の失敗を起点に**エラーメッセージ無しで**落ちていた。Soli0222/sui#471 で踏んだもの。

Soli0222/shared-workflows@119de6b で修正済み。比較対象が無いのだから version 不問として早期に pass させる。ケーステストにも「chart 自体が新規追加された場合」を追加した。

このリポジトリでは今すぐ影響が出る変更ではないが、pin を揃えておく。